### PR TITLE
Fix handling of partial bytes in example code

### DIFF
--- a/examples/WiegandRawTest/WiegandRawTest.ino
+++ b/examples/WiegandRawTest/WiegandRawTest.ino
@@ -8,7 +8,7 @@ void PrintBinary(WiegandNG tempwg) {
 	unsigned int countedBits = tempwg.getBitCounted();
 
 	unsigned int countedBytes = (countedBits/8);
-	if ((countedBytes % 8)>0) countedBytes++;
+	if ((countedBits % 8)>0) countedBytes++;
 	unsigned int bitsUsed = countedBytes * 8;
 	
 	for (int i=bufferSize-countedBytes; i< bufferSize;i++) {


### PR DESCRIPTION
Change what appears to be a typo in the code designed to handle codes that arent multiples of 8 bits.